### PR TITLE
chore(cla): make the CLA gate actually enforce

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,8 +15,8 @@ First PR here? The CLA bot will comment with a one-line signing instruction and
 the `cla` check stays red until you post it. Signing takes one comment, once per
 contributor, and it is what lets us ship your work under the FSL and its
 two-year Apache 2.0 conversion. Details in
-[CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#contributor-license-agreement).
+[CONTRIBUTING.md](https://github.com/Pairlens/trading-terminal/blob/main/CONTRIBUTING.md#contributor-license-agreement).
 
 If your employer owns your work, they execute the
-[Corporate CLA](../blob/main/CLA/corporate-cla.md) instead and list you as a
-designated contributor.
+[Corporate CLA](https://github.com/Pairlens/trading-terminal/blob/main/CLA/corporate-cla.md)
+instead and list you as a designated contributor.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## What and why
+
+<!-- What changed, and what problem it solves. Link related issues. -->
+
+## Checklist
+
+- [ ] `bun run typecheck`, `bun run lint`, `bun run format`, `bun run test` all pass
+- [ ] Tests added or updated for behavior changes
+- [ ] Connector changes pass `bun run test:conformance`
+- [ ] No real exchange API keys, wallet secrets, or seed phrases anywhere in the diff
+
+## Contributor License Agreement
+
+First PR here? The CLA bot will comment with a one-line signing instruction and
+the `cla` check stays red until you post it. Signing takes one comment, once per
+contributor, and it is what lets us ship your work under the FSL and its
+two-year Apache 2.0 conversion. Details in
+[CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#contributor-license-agreement).
+
+If your employer owns your work, they execute the
+[Corporate CLA](../blob/main/CLA/corporate-cla.md) instead and list you as a
+designated contributor.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,14 +4,24 @@ on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened, closed, synchronize]
+    types: [opened, reopened, closed, synchronize]
 
 # CLA Assistant Lite (contributor-assistant/github-action). Blocks PRs until
-# the author has signed the Individual CLA (CLA/individual-cla.md) by posting
-# the signing comment. Signatures are committed to the `cla-signatures` branch
-# of this repo at signatures/version1/cla.json. Corporate contributors sign
-# CLA/corporate-cla.md out-of-band and their designated employees are added to
-# the allowlist.
+# every committer has signed the Individual CLA (CLA/individual-cla.md) by
+# posting the signing comment. Signatures are committed to the `cla-signatures`
+# branch of this repo at signatures/version1/cla.json. Corporate contributors
+# sign CLA/corporate-cla.md out-of-band and their designated employees are
+# added to the allowlist.
+#
+# Two things outside this file make it actually enforce:
+#   1. The `cla-signatures` branch must exist and must stay unprotected — the
+#      action writes the signature file but does not create the branch.
+#   2. The `cla` check is a required status check on main (main-protection
+#      ruleset), so an unsigned PR cannot be merged.
+#
+# The action is pinned by commit SHA: this workflow runs on
+# pull_request_target with write permissions, so a mutable tag would be a
+# supply-chain foothold.
 permissions:
   actions: write
   contents: write
@@ -24,7 +34,7 @@ jobs:
     if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
     steps:
       - name: CLA Assistant Lite
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/CLA/corporate-cla.md
+++ b/CLA/corporate-cla.md
@@ -120,8 +120,11 @@ Licensor.
 
 ## Signature
 
-To execute this Agreement, send a completed and signed copy to the Licensor
-(contact: see the repository's SECURITY.md or the Pairlens website), including:
+To execute this Agreement, open an issue titled "Corporate CLA" on
+[Pairlens/trading-terminal](https://github.com/Pairlens/trading-terminal/issues/new)
+naming your company and your GitHub organization. The Licensor replies with a
+private channel for the signed copy — do not post the completed table or
+Schedule A in a public issue. The completed copy includes:
 
 | Field                          | Value |
 | ------------------------------ | ----- |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,11 @@ The reasoning behind this model is written up on [pairlens.finance/licensing](ht
 
 Before we can merge your first pull request, you need to sign the [Individual CLA](CLA/individual-cla.md). It gives the project the right to distribute your contribution under the licensing model above (including the two-year Apache 2.0 conversion) and includes a patent grant that protects every user of the software. You keep the copyright to your work.
 
-Signing is automatic: when you open your first PR, the CLA bot comments with instructions. You post a single comment ("I have read the CLA Document and I hereby sign the CLA") and the bot records your signature in the repo. That's it, once per contributor, and the PR check flips to green.
+Signing is automatic: when you open your first PR, the CLA bot comments with instructions. You post a single comment ("I have read the CLA Document and I hereby sign the CLA") and the bot records your signature in the repo. That's it, once per contributor, and the `cla` check flips to green. It's a required check, so an unsigned PR can't be merged — that's the only thing standing between a good patch and `main`.
 
-If you contribute as part of your job and your employer owns your work, your employer signs the [Corporate CLA](CLA/corporate-cla.md) instead and lists you as a designated contributor. Reach out via an issue if you need to set that up.
+The bot checks the author of every commit in the PR, not just whoever opened it. If you co-author or cherry-pick someone else's commits, they need to sign too, and commits authored from an email that isn't attached to a GitHub account show up as unknown. `git commit --amend --reset-author` on your own commits fixes that.
+
+If you contribute as part of your job and your employer owns your work, your employer signs the [Corporate CLA](CLA/corporate-cla.md) instead and lists you as a designated contributor. Open an issue titled "Corporate CLA" to start that; the signed copy is exchanged privately, not in the issue.
 
 ## License headers
 

--- a/apps/marketing/src/content/docs/publish-to-registry.md
+++ b/apps/marketing/src/content/docs/publish-to-registry.md
@@ -49,6 +49,13 @@ capabilities and always run sandboxed.
 This is the right path for indicators, panels, themes, and read-only data
 sources.
 
+Like any pull request to the terminal repo, a community submission needs a
+signed Contributor License Agreement before it can be merged. The bot comments
+on your first PR with a one-line instruction, you post it once, and the `cla`
+check goes green. The
+[contributing guide](https://github.com/Pairlens/trading-terminal/blob/main/CONTRIBUTING.md#contributor-license-agreement)
+has the details, including the corporate route if your employer owns your work.
+
 ## Trust model
 
 Non-bootstrap plugins install sandboxed. Full trust, meaning unrestricted


### PR DESCRIPTION
The CLA workflow has been on `main` since the org migration but had **never run**, and three things would have stopped it from working the first time a real contributor showed up.

## What was broken

**1. No signature store.** The `cla-signatures` branch did not exist. CLA Assistant Lite writes `signatures/version1/cla.json` via the contents API but never creates the branch, so the first unsigned PR would have hit `Error occurred when creating the signed contributors file: ... branch not found`, and no signature could ever have been recorded — signing would have been permanently broken, with a confusing error as the only symptom.

Fixed out-of-band: `cla-signatures` now exists as an orphan branch seeded with `{"signedContributors": []}`, unprotected (the action needs to push to it).

**2. The check did not block anything.** The `main-protection` ruleset required only `monorepo-checks` and `rust`. A red CLA check on an unsigned PR was advisory — the PR was still merge-able.

Fixed out-of-band: `cla` is now a required status check on `main`.

**3. Mutable action reference.** The workflow runs on `pull_request_target` holding `contents: write` + `pull-requests: write`, and pulled the action by tag. Anyone who could move `v2.6.1` would get write access to the repo. Now pinned to `ca4a40a7` with the tag as a comment.

## Also here

- `reopened` added to the trigger types, so a closed-then-reopened PR re-reports instead of leaving a stale check.
- A PR template, including what the CLA bot expects on a first contribution.
- CONTRIBUTING documents that the bot checks **every commit author**, not the PR opener, and how to fix commits authored from an unlinked email — that is the most common way this check confuses people.
- The Corporate CLA pointed at SECURITY.md for a contact address; SECURITY.md has no address, only a security-advisory link. Replaced with the issue route, with a note that the signed copy is exchanged privately rather than posted in a public issue.

## Verification

The `cla` check on this PR is the first live run of the workflow. It exercises the allowlist path (author is allowlisted), which proves the action resolves, the token permissions are sufficient, and the check reports under the context name the ruleset now requires. The SHA pin and the `reopened` trigger only take effect once this is on `main`, since `pull_request_target` reads the workflow from the base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)