### PR TITLE
test(cla): temporarily drop the owner from the CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -41,7 +41,7 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/Pairlens/trading-terminal/blob/main/CLA/individual-cla.md'
           branch: 'cla-signatures'
-          allowlist: juanignaciomolina,dependabot[bot],github-actions[bot],claude[bot]
+          allowlist: dependabot[bot],github-actions[bot],claude[bot]
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
           custom-notsigned-prcomment: >
             Thanks for the contribution! Before we can merge this, we need you


### PR DESCRIPTION
Half one of a two-PR verification. The unsigned signing path (bot comment, signature write to `cla-signatures`, check flipping green) has never run, and `pull_request_target` resolves the workflow from the **default branch** rather than the PR's base branch, so it cannot be exercised from a side branch. Dropping the owner from the allowlist on `main` is the only way to become an unsigned committer.

Restored immediately by the follow-up PR. Window is a few minutes, and during it the behavior for any other contributor is the correct one anyway: they get asked to sign.

This PR's own `cla` check runs against main's current workflow, where the owner is still allowlisted, so it passes.