### PR TITLE
test(cla): exercise the unsigned signing path (throwaway)

### DIFF
--- a/CLA-VERIFY.md
+++ b/CLA-VERIFY.md
@@ -1,0 +1,1 @@
+Throwaway file used to exercise the CLA signing path. Deleted with the branch.


### PR DESCRIPTION
Throwaway PR, closed without merging. With the owner temporarily off the allowlist, this PR's committer is unsigned, so the bot has to run its real flow: post the sign request, fail the `cla` check, then record the signature to `cla-signatures` and flip the check green once the signing comment is posted.

The allowlist is restored by a follow-up PR right after.