### PR TITLE
feat(billing): migrate Pairlens Intelligence from Polar to Stripe

### DIFF
--- a/apps/marketing/src/content/legal/privacy.mdx
+++ b/apps/marketing/src/content/legal/privacy.mdx
@@ -111,15 +111,15 @@ Section 5 covers this in full, because it deserves its own section.
 
 ### 4.4 Billing
 
-If you subscribe to Pairlens Intelligence, we store your Polar customer
-identifier, the product and price you bought, your subscription status, the
-current period end, whether you have scheduled a cancellation, and a ledger of
-expired credit packs.
+If you subscribe to Pairlens Intelligence, we store your Stripe customer
+identifier and a credit ledger: the credits granted for each billing cycle or
+credit-pack purchase, each metered AI request (model name, token counts, and
+the credits it cost — never the content of your prompts), and any credits
+that expired unused.
 
-**We never see your card.** Checkout, payment processing, invoicing, and sales
-tax are handled by Polar as our merchant of record. Your payment details go to
-them and their payment processors, not to us. Their privacy policy governs
-that part.
+**We never see your card.** Checkout, card processing, and invoicing are
+handled by Stripe as our payment processor. Your payment details go directly
+to Stripe, not to us. Their privacy policy governs that part.
 
 ### 4.5 Analytics and error reporting
 

--- a/apps/marketing/src/content/legal/terms.mdx
+++ b/apps/marketing/src/content/legal/terms.mdx
@@ -193,11 +193,12 @@ provider key.
 spent before your monthly allowance, and **any unused pack credits expire 30
 days after purchase**.
 
-**Billing.** Polar acts as our merchant of record. Your purchase contract for
-payment purposes is with Polar, their terms apply to the payment itself, and
-they handle invoicing and tax. Subscriptions renew automatically each month
-until cancelled. We will give you at least 30 days' notice by email before any
-price increase takes effect, and you can cancel before it does.
+**Billing.** Payments are processed by Stripe. Your purchase contract is with
+us; Stripe handles the payment itself under its own terms and issues invoices
+on our behalf. Prices are shown exclusive of tax, and applicable tax is added
+at checkout. Subscriptions renew automatically each month until cancelled. We
+will give you at least 30 days' notice by email before any price increase
+takes effect, and you can cancel before it does.
 
 **Cancelling.** Cancel at any time from the billing portal. Your subscription
 runs to the end of the period you have paid for and then stops. We do not

--- a/apps/marketing/src/lib/legal.ts
+++ b/apps/marketing/src/lib/legal.ts
@@ -172,12 +172,12 @@ export const SUBPROCESSORS: ReadonlyArray<Subprocessor> = [
     href: 'https://vercel.com/docs/ai-gateway',
   },
   {
-    name: 'Polar Software Inc.',
+    name: 'Stripe, Inc.',
     purpose:
-      'Merchant of record for Pairlens Intelligence: checkout, payment processing, subscription management, invoicing, and sales tax. Polar is a separate controller for the payment data it collects.',
+      'Payment processing for Pairlens Intelligence: checkout, card processing, subscription management, invoicing, and tax calculation. Stripe is a separate controller for the payment data it collects; card numbers never touch Pairlens servers.',
     location: 'United States, European Union',
-    safeguard: 'Standard Contractual Clauses',
-    href: 'https://polar.sh/legal/privacy',
+    safeguard: 'Standard Contractual Clauses, EU-US Data Privacy Framework',
+    href: 'https://stripe.com/privacy',
   },
   {
     name: 'Resend, Inc.',

--- a/apps/terminal/src/components/billing/billing-state-sync.tsx
+++ b/apps/terminal/src/components/billing/billing-state-sync.tsx
@@ -5,7 +5,7 @@ import { useBillingState } from '@/hooks/use-billing'
 /**
  * Render-null global subscriber that keeps the Intelligence billing state
  * mounted for the whole terminal session. This is what makes returning from
- * a Polar checkout (completed in the system browser) feel instant: the query
+ * a Stripe checkout (completed in the system browser) feel instant: the query
  * refetches on window focus, and its plan-transition effect re-syncs
  * entitlements and fires the activation toast — regardless of which panels
  * happen to be open. Signed-out / standalone sessions keep the query

--- a/apps/terminal/src/hooks/use-billing.ts
+++ b/apps/terminal/src/hooks/use-billing.ts
@@ -17,7 +17,7 @@ import { openExternalUrl } from '@/lib/platform'
 // ---------------------------------------------------------------------------
 // Pairlens Intelligence billing state + checkout/portal actions.
 //
-// Checkout and the customer portal are hosted Polar pages opened in the
+// Checkout and the billing portal are hosted Stripe pages opened in the
 // system browser (never the app webview). While the user pays over there,
 // nothing signals this window directly — so the state query refetches on
 // window focus, and a plan/status transition re-syncs plugin entitlements via
@@ -38,7 +38,7 @@ export function useBillingState() {
   })
 
   // Announce subscription transitions so the capability gates react without
-  // a reload (e.g. the user comes back from Polar checkout) — and make the
+  // a reload (e.g. the user comes back from Stripe checkout) — and make the
   // payment moments visible: checkout happens in another browser, so these
   // toasts ARE the in-app payment confirmation (for both subscriptions and
   // one-time credit packs, which change the pack count, not the plan).
@@ -89,7 +89,7 @@ export function useBillingState() {
   return query
 }
 
-/** Open the hosted Polar checkout for a plan in the system browser. */
+/** Open the hosted Stripe checkout for a plan in the system browser. */
 export function useIntelligenceCheckout() {
   return useMutation({
     mutationFn: async (plan: IntelligencePlanId) => {
@@ -109,7 +109,7 @@ export function usePackCheckout() {
   })
 }
 
-/** Open the pre-authenticated Polar customer portal in the system browser. */
+/** Open the pre-authenticated Stripe billing portal in the system browser. */
 export function useBillingPortal() {
   return useMutation({
     mutationFn: async () => {

--- a/apps/terminal/src/lib/api.ts
+++ b/apps/terminal/src/lib/api.ts
@@ -547,11 +547,11 @@ export const api = {
   deleteAccount: () =>
     fetchApi<AccountDeletionSummary>('/api/account', { method: 'DELETE' }),
 
-  // ---- Pairlens Intelligence billing (Polar via the App Server) ----
+  // ---- Pairlens Intelligence billing (Stripe via the App Server) ----
 
   getBillingState: () => fetchApi<BillingState>('/api/billing/state'),
 
-  /** Returns the hosted Polar checkout URL — open it in the system browser. */
+  /** Returns the hosted Stripe checkout URL — open it in the system browser. */
   createBillingCheckout: (plan: IntelligencePlanId) =>
     fetchApi<{ url: string; plan: IntelligencePlan }>('/api/billing/checkout', {
       method: 'POST',
@@ -565,7 +565,7 @@ export const api = {
       body: JSON.stringify({ pack }),
     }),
 
-  /** Returns the pre-authenticated Polar customer-portal URL. */
+  /** Returns the pre-authenticated Stripe billing-portal URL. */
   createBillingPortal: () =>
     fetchApi<{ url: string }>('/api/billing/portal', { method: 'POST' }),
 

--- a/apps/terminal/src/lib/platform.ts
+++ b/apps/terminal/src/lib/platform.ts
@@ -73,7 +73,7 @@ async function reportWindowFailure(err: unknown): Promise<void> {
 
 /**
  * Open a URL in the user's default system browser. Used for flows that must
- * NOT run inside the app webview — Polar checkout / customer portal pages
+ * NOT run inside the app webview — Stripe checkout / billing portal pages
  * (payment forms belong in a real browser session). In the browser build
  * this is a plain new tab.
  */

--- a/apps/terminal/src/routes/checkout.success.tsx
+++ b/apps/terminal/src/routes/checkout.success.tsx
@@ -17,10 +17,10 @@ import type {
   IntelligencePlanId,
 } from '@pairlens/shared/billing-types'
 
-// Post-checkout landing — where Polar redirects after a successful payment.
+// Post-checkout landing — where Stripe redirects after a successful payment.
 //
 // Standalone on purpose: checkout usually completes in the system browser
-// (the desktop app opens Polar externally), so this page may load in a
+// (the desktop app opens Stripe externally), so this page may load in a
 // browser with no Pairlens state at all. It must NOT sit inside the
 // _terminal layout, whose first-run gate would bounce a fresh profile to
 // /onboarding — turning the "you just paid" moment into a setup wizard.

--- a/packages/shared/src/account-types.ts
+++ b/packages/shared/src/account-types.ts
@@ -144,23 +144,28 @@ export type AccountExportCommunityWorkspace = {
 }
 
 export type AccountExportBilling = {
-  /** Polar customer id, when the account ever reached checkout. */
-  polarCustomerId: string | null
-  subscriptions: Array<{
+  /** Stripe customer id, when the account ever reached checkout. */
+  stripeCustomerId: string | null
+  /**
+   * The credit ledger's grant side: one entry per subscription cycle or
+   * pack purchase, including what the expiry sweep forfeited.
+   */
+  creditGrants: Array<{
     id: string
-    polarProductId: string
-    polarPriceId: string
-    status: string
-    currentPeriodEnd: string | null
-    cancelAtPeriodEnd: boolean
-    createdAt: string
-    updatedAt: string
+    source: string
+    packId: string | null
+    credits: number
+    grantedAt: string
+    expiresAt: string
+    forfeitedUnits: number | null
+    forfeitedAt: string | null
   }>
-  /** Credit packs whose unused remainder expired. */
-  creditPackForfeits: Array<{
-    grantId: string
-    units: number
-    forfeitedAt: string
+  /** The ledger's spend side: one entry per metered AI request. */
+  usageEvents: Array<{
+    name: string
+    credits: number
+    metadata: Record<string, unknown>
+    createdAt: string
   }>
 }
 
@@ -230,7 +235,7 @@ export type AnalyticsErasureOutcome = 'deleted' | 'not_configured' | 'failed'
 /** What `DELETE /api/account` actually erased. */
 export type AccountDeletionSummary = {
   ok: true
-  /** Active Polar subscriptions cancelled as part of the deletion. */
+  /** Active Stripe subscriptions cancelled as part of the deletion. */
   subscriptionsCancelled: number
   /** True when the stored avatar object was removed from object storage. */
   avatarDeleted: boolean

--- a/packages/shared/src/billing-types.ts
+++ b/packages/shared/src/billing-types.ts
@@ -4,22 +4,24 @@
 // Pairlens Intelligence billing contract
 //
 // Pairlens accounts are always free. "Pairlens Intelligence" is a paid add-on
-// subscription (billed via Polar.sh, managed by the App Server) that unlocks
+// subscription (billed via Stripe, managed by the App Server) that unlocks
 // AI usage with Pairlens as the provider — the hosted inference proxy and the
 // hosted web-research search. Bring-your-own-key AI provider plugins
 // (Anthropic, OpenAI, Groq, OpenRouter, Tavily, Exa, ...) are never gated.
 //
 // Usage is metered in CREDITS: 1 credit = $0.001 USD of underlying cost.
 // Each plan grants a monthly credit budget of roughly 70% of the
-// subscription price (~30% gross margin covers payment processing, Polar's
-// merchant-of-record fee, and profit), rounded to a friendly number. Credits
+// subscription price (~30% gross margin covers payment processing fees,
+// sales tax handling, and profit), rounded to a friendly number. Credits
 // reset every billing cycle and do NOT roll over. All hosted AI usage —
 // inference (any model) and web research — draws from the same budget.
 //
-// The App Server owns all Polar interaction (checkout, customer portal,
-// webhooks, usage ingestion, balance checks). The terminal only consumes:
-//   - GET /api/billing/state            → BillingState (below)
-//   - BetterAuth Polar client endpoints → checkout / customer portal
+// The App Server owns all Stripe interaction (checkout, billing portal,
+// webhooks) AND the usage ledger itself — credit grants and usage events
+// live in its Postgres database, not with the payment processor. The
+// terminal only consumes:
+//   - GET /api/billing/state             → BillingState (below)
+//   - POST /api/billing/checkout|portal  → hosted Stripe URLs
 // and receives typed 402 errors from gated AI routes.
 // ---------------------------------------------------------------------------
 
@@ -40,9 +42,10 @@ export type IntelligencePlan = {
 
 /**
  * Plan catalog. `monthlyCredits` ≈ price × 70% in credits (≈30% margin),
- * rounded to a friendly number. The Polar products/benefits are provisioned
- * from this catalog (see the App Server's polar setup script) — rerun it
- * after changing these so the meter-credit benefits follow.
+ * rounded to a friendly number. The Stripe products/prices are provisioned
+ * from this catalog (see the App Server's stripe setup script) — rerun it
+ * after changing prices; credit budgets take effect from the next cycle
+ * grant without touching Stripe at all (the ledger is ours).
  */
 export const INTELLIGENCE_PLANS: Record<IntelligencePlanId, IntelligencePlan> =
   {
@@ -65,11 +68,11 @@ export const INTELLIGENCE_PLANS: Record<IntelligencePlanId, IntelligencePlan> =
 // ---------------------------------------------------------------------------
 // Credit packs — one-time top-ups (Intelligence Max subscribers only)
 //
-// Extra credits land on the same meter as the monthly budget and are spent
-// alongside it. They EXPIRE 30 days after purchase: Polar's one-time credit
-// grants are permanent, so the App Server enforces expiry by forfeiting each
-// pack's unused remainder (pack credits are counted as consumed FIRST, so an
-// actively-used pack forfeits little or nothing).
+// Extra credits land on the same ledger as the monthly budget and are spent
+// alongside it. They EXPIRE 30 days after purchase: the App Server enforces
+// expiry by forfeiting each pack's unused remainder (pack credits are
+// counted as consumed FIRST, so an actively-used pack forfeits little or
+// nothing).
 // ---------------------------------------------------------------------------
 
 export type CreditPackId = 'pack-10' | 'pack-20' | 'pack-50' | 'pack-100'
@@ -127,7 +130,7 @@ export type IntelligenceSubscriptionStatus = 'none' | 'active' | 'canceled'
 
 /** Payload of GET /api/billing/state (auth required). */
 export type BillingState = {
-  /** False when the server has no Polar configuration (self-hosted). */
+  /** False when the server has no Stripe configuration (self-hosted). */
   billingEnabled: boolean
   plan: IntelligencePlanId | null
   status: IntelligenceSubscriptionStatus
@@ -140,7 +143,7 @@ export type BillingState = {
   /**
    * True for complimentary access (core contributors / testing, granted via
    * the App Server's BILLING_COMPLIMENTARY_EMAILS allowlist): full
-   * Intelligence access, usage not metered against a Polar subscription.
+   * Intelligence access, usage not metered against a subscription.
    */
   complimentary?: boolean
   /**
@@ -151,7 +154,7 @@ export type BillingState = {
   packs?: Array<ActiveCreditPack>
 }
 
-/** Metered usage event types ingested to Polar. Same meter, same budget. */
+/** Metered usage event types recorded in the ledger. Same budget. */
 export type IntelligenceUsageEvent = 'ai_usage' | 'web_research'
 
 /**


### PR DESCRIPTION
Polar blocked us from processing payments (financial nature of the terminal), so Stripe takes over as payment processor. No users existed, so nothing is migrated — the Polar era is simply replaced.

The client-facing contract is untouched: same `BillingState` shape, same typed 402 codes, same checkout/portal-URL flow through our own REST routes (the desktop app still opens hosted pages in the system browser). What changes here:

- **billing-types / account-types** (mirrored from pairlens-server): contract docs now describe Stripe + our own Postgres credit ledger; the account export carries the Stripe customer id and the full ledger (grants + usage events) instead of Polar rows
- **Legal**: Stripe is a payment processor, not a merchant of record — Pairlens is the merchant now. Privacy §4.4, the terms' billing section, and the subprocessor list updated accordingly (prices tax-exclusive, tax added at checkout)
- Comment-level Polar mentions swept from the billing hooks/routes/api

Server-side counterpart: pairlens-server PR "feat(billing): migrate from Polar to Stripe with an in-house credit ledger" (`claude/stripe-migration`). Verified end-to-end against the real Pairlens Sandbox: Max subscription + credit-pack checkout paid with test cards, webhooks 200, ledger rows correct.

Safe to merge independently of the server PR — these are docs/types/comments; the running Polar backend never sees them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)