### PR TITLE
chore(marketing): bump fast-financial-charts to ^2.0.0

### DIFF
--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -25,7 +25,7 @@
     "@fontsource-variable/hanken-grotesk": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.5",
     "@fontsource-variable/space-grotesk": "^5.2.10",
-    "@pairlens/fast-financial-charts": "^1.5.2",
+    "@pairlens/fast-financial-charts": "^2.0.0",
     "@pairlens/shared": "workspace:*",
     "@pairlens/ui": "workspace:*",
     "@tailwindcss/vite": "^4.2.0",

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
     },
     "apps/desktop": {
       "name": "@pairlens/desktop",
-      "version": "0.1.4",
+      "version": "0.4.0",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-shell": "^2.2.1",
@@ -55,7 +55,7 @@
         "@fontsource-variable/hanken-grotesk": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.5",
         "@fontsource-variable/space-grotesk": "^5.2.10",
-        "@pairlens/fast-financial-charts": "^1.5.2",
+        "@pairlens/fast-financial-charts": "^2.0.0",
         "@pairlens/shared": "workspace:*",
         "@pairlens/ui": "workspace:*",
         "@tailwindcss/vite": "^4.2.0",
@@ -3149,6 +3149,8 @@
     "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
+
+    "@pairlens/marketing/@pairlens/fast-financial-charts": ["@pairlens/fast-financial-charts@2.0.0", "", { "peerDependencies": { "@types/react": ">=19", "react": ">=19", "react-dom": ">=19" }, "optionalPeers": ["@types/react", "react", "react-dom"] }, "sha512-fCgOP0l2ZFdb8t53HZePlY4CaT6SIEi/xTFX2qLLLfOf7Mm3HlIKvvFnl0TjDtSgl83eAlKz0xeQvvsTBoA3Hw=="],
 
     "@pairlens/terminal/@tauri-apps/api": ["@tauri-apps/api@2.11.1", "", {}, "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA=="],
 


### PR DESCRIPTION
## What

Bumps `@pairlens/fast-financial-charts` from `^1.5.2` to `^2.0.0` in `apps/marketing`.

## Why

[v2.0.0](https://www.npmjs.com/package/@pairlens/fast-financial-charts) ships prebuilt ESM + CJS with type declarations instead of raw TypeScript source. Previously the published package resolved its entry points to `.ts`/`.tsx` files, so `npm i` followed by `import` failed on Next.js and on webpack without a TypeScript loader.

The marketing site was pinned to `^1.5.2`, and that range excludes `2.0.0` — so `/charts` was demoing a version that visitors installing `latest` would not get.

## Verification

Run against the published 2.0.0 tarball, not a local build:

- `astro build` — succeeds, 51 pages
- `astro check` — **0 errors**, 0 warnings (the 4 hints are pre-existing `navigator.platform` deprecations, unrelated)
- Vite still code-splits the indicator Web Worker into its own 41.7 kB chunk, and the emitted `/_astro/indicator.worker-*.js` URL resolves to a real asset

No source changes were needed. The demo components (`ChartsLiveDemo`, `ChartGallery`, `StyleShowcase`, `DrawingRail`, `LiveChart`, `chart-kit`) use only public subpath exports, and the public API is unchanged in 2.0.0 — the major bump is packaging-only.

## Deliberately out of scope

`apps/terminal` (`^1.5.2`) and the repo root (`^1.5.3`) are **left on 1.5.x**. Bun installs both majors side by side, so this is safe, but it does mean two copies in the lockfile until they are bumped too.

Moving the terminal is a bigger job than a version bump — it is the production trading app, and it deserves its own PR with a real build-and-run pass rather than being folded in here. The root-level dependency looks vestigial (a charting library as a direct dependency of a monorepo root) and is probably better deleted than bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)