### PR TITLE
fix(assistant): switching History no longer aborts a live answer

### DIFF
--- a/apps/marketing/src/content/docs/ai-copilot.md
+++ b/apps/marketing/src/content/docs/ai-copilot.md
@@ -4,7 +4,7 @@ description: An assistant that can see your screen, read any market, draw on you
 group: traders
 order: 4
 eyebrow: For traders
-updated: 1 SEP 2026
+updated: 4 SEP 2026
 readTime: 10 min read
 ---
 
@@ -107,12 +107,16 @@ Minimizing does not stop anything. The orb reports what it is doing in place of
 the suggestion (**Thinking...**, **Using tools...**, **Looking on the web...**),
 so a collapsed assistant is never a black box. Navigating away does not stop it
 either: ask for a backtest, go read the order book, and the run is still going
-when you come back.
+when you come back. Switching to another conversation in History is the same:
+the answer keeps writing in the background, and it is there when you return.
 
 ## Your conversations
 
 Down the left of the window, **History** holds every conversation, newest first.
 Clicking a row opens it exactly as you left it, tool activity and cards included.
+Switching rows does not stop a run that is still writing: come back and the rest
+of the answer is there, the same way minimizing keeps it going. Deleting a
+conversation is the one way a live run on that thread is aborted.
 
 Threads name themselves from your first message, then get a better title in the
 background. Double-click a row to rename it. Deleting asks first and is not

--- a/apps/terminal/src/components/assistant-dock/__tests__/conversation-switch.test.ts
+++ b/apps/terminal/src/components/assistant-dock/__tests__/conversation-switch.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Juan Ignacio Molina Estrada
+// SPDX-License-Identifier: FSL-1.1-Apache-2.0
+/**
+ * The terminal has no React test renderer, so these pin the wiring that
+ * keeps a run alive when History changes. Undo any one of them and a
+ * click on another row aborts the answer again, with no type error.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, test } from 'bun:test'
+
+const SOURCE = readFileSync(
+  join(import.meta.dir, '..', 'assistant-conversation.tsx'),
+  'utf8',
+)
+
+describe('switching History does not abort a run', () => {
+  test('each thread has its own Chat, handed to useChat rather than rebuilt by id', () => {
+    // Passing `{ chat }` is what lets the previous Chat keep streaming:
+    // the hook swaps the subscription and does not call stop(). Keying
+    // useChat on `id` instead would construct a new Chat and orphan the
+    // run the way the old switch effect had to stop() to avoid.
+    expect(SOURCE).toMatch(/import \{ Chat, useChat \} from '@ai-sdk\/react'/)
+    expect(SOURCE).toContain('sessions.get(conversationId)')
+    expect(SOURCE).toMatch(/useChat\(\{[\s\S]*?chat,/)
+  })
+
+  test('a History click does not call stop or drop in-memory screenshots', () => {
+    // The old switch effect stopped the stream, wrote the half-answer,
+    // cleared chart captures, then moved threadId. Minimizing already
+    // keeps the run; switching rows has to as well.
+    expect(SOURCE).not.toContain('stopRef.current()')
+    expect(SOURCE).not.toMatch(/clearScreenshots\(\)/)
+  })
+})

--- a/apps/terminal/src/components/assistant-dock/assistant-conversation.tsx
+++ b/apps/terminal/src/components/assistant-dock/assistant-conversation.tsx
@@ -10,11 +10,10 @@
 // long run keep working while the user goes back to the chart.
 //
 // It shows ONE thread at a time out of however many the user has, and
-// the thread it shows is the store's `activeId`. The chat is keyed on
-// that id, so switching rebuilds the AI SDK's Chat around the other
-// thread's messages rather than replaying them into the live one. What
-// makes that safe is the switch effect below: the outgoing run is
-// stopped and written out BEFORE the id the chat is keyed on moves.
+// the thread it shows is the store's `activeId`. Each thread keeps its
+// own Chat in AssistantChatSessions, so switching History only changes
+// which one is on screen. The previous run keeps streaming, the same
+// way minimizing the dock does.
 
 import {
   useCallback,
@@ -23,10 +22,11 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
 } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from '@tanstack/react-router'
-import { useChat } from '@ai-sdk/react'
+import { Chat, useChat } from '@ai-sdk/react'
 import { lastAssistantMessageIsCompleteWithToolCalls } from 'ai'
 import {
   ArrowDown,
@@ -97,10 +97,8 @@ import { humanizeToolName } from '@/lib/copilot/tool-labels'
 import { runSurfaceAction } from '@/lib/assistant-core/surface-tools'
 import { deriveRunStatus } from '@/lib/assistant-core/run-status'
 import { hasParkedToolCall } from '@/lib/assistant-core/run-gate'
-import {
-  clearScreenshots,
-  getScreenshot,
-} from '@/lib/assistant-core/screenshot-store'
+import { AssistantChatSessions } from '@/lib/assistant-core/chat-sessions'
+import { getScreenshot } from '@/lib/assistant-core/screenshot-store'
 import { useAssistantStore } from '@/stores/assistant-store'
 import { generateConversationTitle } from '@/lib/assistant-core/conversation-title'
 import {
@@ -201,8 +199,9 @@ export function AssistantConversation(props: AssistantConversationProps) {
  * Resolves which thread is on screen and hands it down as a plain prop.
  *
  * Split out so the store is only read once the assistant is actually
- * usable, and so the chat below can key itself on an id it is simply
- * given. The ensure runs in a layout effect rather than during render:
+ * usable, and so the chat below is given a plain id rather than
+ * subscribing to the whole index. The ensure runs in a layout effect
+ * rather than during render:
  * creating the first conversation is a store write, and a store write
  * mid-render is a write the conversation rail is also subscribed to.
  * Before paint, so the empty frame is never shown.
@@ -270,25 +269,6 @@ function AssistantConversationInner({
   const depsRef = useRef(deps)
   depsRef.current = deps
 
-  // ── Which thread is on screen ─────────────────────────────────────
-  //
-  // The chat is keyed on `threadId`, NOT on the store's `activeId`
-  // directly. The two are the same except for the one render between a
-  // row being clicked and the switch effect below having stopped and
-  // written out the run that was in flight. Keying straight off the
-  // store would rebuild the Chat first and orphan that run: it would
-  // keep streaming into an object nothing renders, and the half answer
-  // it had already produced would never be written anywhere.
-  const [threadId, setThreadId] = useState(conversationId)
-  // Read through the store's own cache rather than `messagesOf`, which
-  // writes on a miss: `select` and `create` both load the thread before
-  // they publish the id, so by the time it reaches here it is cached.
-  // Unsubscribed on purpose. `useChat` only reads this when it builds a
-  // Chat, which is exactly when `threadId` changes, and subscribing
-  // would rerender the whole conversation on every persisted token.
-  const storedMessages =
-    useAssistantConversationsStore.getState().threads[threadId] ?? EMPTY_THREAD
-
   const transport = useMemo(
     () =>
       new AssistantTransport({
@@ -298,8 +278,86 @@ function AssistantConversationInner({
     [],
   )
 
-  const runStartRef = useRef(0)
-  const runToolCallsRef = useRef(0)
+  const hostRef = useRef({ navigate, resolveMarketRef, scheduleCheck })
+  hostRef.current = { navigate, resolveMarketRef, scheduleCheck }
+
+  // Per-thread counters: onFinish is closed over the Chat at construction,
+  // so a shared pair of refs would credit a background run to whichever
+  // thread happened to send last.
+  const runStatsRef = useRef(
+    new Map<string, { start: number; tools: number }>(),
+  )
+  const queuedByIdRef = useRef(new Map<string, string>())
+  const [queuedEpoch, setQueuedEpoch] = useState(0)
+
+  // One Chat per thread, kept across History clicks. `useChat({ chat })`
+  // swaps the subscription without calling stop() on the previous one.
+  const sessionsRef = useRef<AssistantChatSessions<Chat<UIMessage>> | null>(
+    null,
+  )
+  if (!sessionsRef.current) {
+    sessionsRef.current = new AssistantChatSessions({
+      debounceMs: PERSIST_DEBOUNCE_MS,
+      persist: (id, messages) => {
+        useAssistantConversationsStore
+          .getState()
+          .setMessages(id, messages as Array<UIMessage>)
+      },
+      onReady: (id, chat) => {
+        const text = queuedByIdRef.current.get(id)
+        if (!text) return
+        const thread = chat.messages as Array<UIMessage>
+        if (hasParkedToolCall(thread) || findPendingQuestion(thread)) return
+        queuedByIdRef.current.delete(id)
+        setQueuedEpoch((n) => n + 1)
+        runStatsRef.current.set(id, { start: Date.now(), tools: 0 })
+        void chat.sendMessage({ text })
+      },
+      create: (id) =>
+        new Chat({
+          id,
+          messages:
+            useAssistantConversationsStore.getState().threads[id] ??
+            EMPTY_THREAD,
+          transport,
+          // ask_user and approval-gated surface actions have no execute:
+          // the run parks on them and resumes by itself once every call
+          // in the last message carries a result. Must live on the Chat:
+          // useChat does not refresh these callbacks when `chat` is passed.
+          sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+          onToolCall: ({ toolCall }) => {
+            const stats = runStatsRef.current.get(id) ?? {
+              start: 0,
+              tools: 0,
+            }
+            stats.tools += 1
+            runStatsRef.current.set(id, stats)
+            const host = hostRef.current
+            executeClientTool(
+              toolCall.toolName,
+              toolCall.input as Record<string, unknown> | undefined,
+              {
+                chart: depsRef.current.getChart(),
+                navigate: host.navigate,
+                resolveMarketRef: host.resolveMarketRef,
+                scheduleCheck: host.scheduleCheck,
+                toolCallId: toolCall.toolCallId,
+              },
+            )
+          },
+          onFinish: () => {
+            const stats = runStatsRef.current.get(id)
+            track('assistant_run_completed', {
+              outcome: 'success',
+              tool_calls: stats?.tools ?? 0,
+              duration_ms: stats?.start ? Date.now() - stats.start : 0,
+            })
+          },
+        }),
+    })
+  }
+  const sessions = sessionsRef.current
+  const chat = sessions.get(conversationId)
 
   const {
     messages,
@@ -310,41 +368,44 @@ function AssistantConversationInner({
     regenerate,
     addToolResult,
   } = useChat({
-    // Changing this is what swaps threads: the SDK rebuilds its Chat
-    // around `messages` whenever the id moves.
-    id: threadId,
-    messages: storedMessages,
-    transport,
+    chat,
     experimental_throttle: STREAM_THROTTLE_MS,
-    // ask_user and approval-gated surface actions have no execute: the
-    // run parks on them and resumes by itself once every call in the
-    // last message carries a result.
-    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
-    onToolCall: ({ toolCall }) => {
-      runToolCallsRef.current += 1
-      executeClientTool(
-        toolCall.toolName,
-        toolCall.input as Record<string, unknown> | undefined,
-        {
-          chart: depsRef.current.getChart(),
-          navigate,
-          resolveMarketRef,
-          scheduleCheck,
-          toolCallId: toolCall.toolCallId,
-        },
-      )
-    },
-    onFinish: () => {
-      track('assistant_run_completed', {
-        outcome: 'success',
-        tool_calls: runToolCallsRef.current,
-        duration_ms: runStartRef.current ? Date.now() - runStartRef.current : 0,
-      })
-    },
   })
 
+  const liveIds = useAssistantConversationsStore((state) =>
+    state.conversations.map((row) => row.id).join('\0'),
+  )
+  useEffect(() => {
+    if (!liveIds) return
+    const ids = liveIds.split('\0')
+    sessions.prune(ids)
+    const live = new Set(ids)
+    for (const id of queuedByIdRef.current.keys()) {
+      if (!live.has(id)) queuedByIdRef.current.delete(id)
+    }
+  }, [liveIds, sessions])
+  useEffect(
+    () => () => {
+      sessionsRef.current?.dispose()
+    },
+    [],
+  )
+
   // ── Run status, reported up to the orb ────────────────────────────
-  const runStatus = deriveRunStatus(messages, status)
+  //
+  // Prefer the thread on screen, then any Chat still working in the
+  // background, so switching away from a live answer does not make the
+  // orb look idle.
+  const bgRevision = useSyncExternalStore(
+    sessions.subscribe,
+    sessions.getSnapshot,
+    sessions.getSnapshot,
+  )
+  const visibleStatus = deriveRunStatus(messages, status)
+  const runStatus =
+    visibleStatus.phase !== 'idle' || bgRevision < 0
+      ? visibleStatus
+      : sessions.busiestStatus()
   const lastReportedRef = useRef<string>('')
   useEffect(() => {
     const key = `${runStatus.phase}:${runStatus.toolName ?? ''}`
@@ -352,83 +413,6 @@ function AssistantConversationInner({
     lastReportedRef.current = key
     onStatusChange?.(runStatus)
   }, [runStatus, onStatusChange])
-
-  // ── Local persistence ─────────────────────────────────────────────
-  //
-  // Threads are written to this device and nowhere else. There is no
-  // account copy any more, which is why the whole `UIMessage` goes down
-  // rather than the flattened text the server used to accept: tool
-  // calls, research cards and order proposals all come back on reload.
-  //
-  // Debounced, because a streaming answer changes the array on every
-  // token and serializing a long thread that often would be felt. The
-  // pending write carries the id it was scheduled for, so a flush that
-  // lands after a switch still writes to the thread it came from.
-  const messagesRef = useRef(messages)
-  messagesRef.current = messages
-  const pendingWriteRef = useRef<{
-    id: string
-    timer: ReturnType<typeof setTimeout>
-  } | null>(null)
-
-  const writeThreadNow = useCallback((id: string) => {
-    const pending = pendingWriteRef.current
-    if (pending?.id === id) {
-      clearTimeout(pending.timer)
-      pendingWriteRef.current = null
-    }
-    useAssistantConversationsStore
-      .getState()
-      .setMessages(id, messagesRef.current)
-  }, [])
-
-  useEffect(() => {
-    // An empty thread is left alone. Opening the dock and closing it
-    // again should not stamp a conversation as touched.
-    if (messages.length === 0) return
-    // A finished run is written at once: the answer is complete and the
-    // window may be closed the moment it lands.
-    if (status === 'ready' || status === 'error') {
-      writeThreadNow(threadId)
-      return
-    }
-    if (pendingWriteRef.current?.id === threadId) return
-    const timer = setTimeout(() => {
-      pendingWriteRef.current = null
-      useAssistantConversationsStore
-        .getState()
-        .setMessages(threadId, messagesRef.current)
-    }, PERSIST_DEBOUNCE_MS)
-    pendingWriteRef.current = { id: threadId, timer }
-  }, [messages, status, threadId, writeThreadNow])
-
-  useEffect(
-    () => () => {
-      const pending = pendingWriteRef.current
-      if (pending) clearTimeout(pending.timer)
-    },
-    [],
-  )
-
-  // ── Switching threads ─────────────────────────────────────────────
-  //
-  // Runs BEFORE `threadId` moves, which is the whole reason the chat is
-  // not keyed off the store directly. Stop first so nothing keeps
-  // streaming into a Chat about to be discarded, then write what did
-  // arrive, then let the render that swaps the thread happen.
-  const stopRef = useRef(stop)
-  stopRef.current = stop
-  useEffect(() => {
-    if (conversationId === threadId) return
-    stopRef.current()
-    if (messagesRef.current.length > 0) writeThreadNow(threadId)
-    // Chart captures are held in memory and never written down, so they
-    // cannot follow a thread across a reload anyway. Dropping them here
-    // is what keeps a long session of switching from accumulating PNGs
-    // for threads nobody is looking at.
-    clearScreenshots()
-    setThreadId(conversationId)
-  }, [conversationId, threadId, writeThreadNow])
 
   // ── Naming the thread ─────────────────────────────────────────────
   //
@@ -439,28 +423,30 @@ function AssistantConversationInner({
   // already readable.
   const titledRef = useRef<Set<string>>(new Set())
   useEffect(() => {
-    if (messages.length === 0 || titledRef.current.has(threadId)) return
+    if (messages.length === 0 || titledRef.current.has(conversationId)) return
     const first = messages.find((message) => message.role === 'user')
     const seed = first ? textOf(first) : ''
     if (!seed.trim()) return
-    titledRef.current.add(threadId)
+    titledRef.current.add(conversationId)
 
     const store = useAssistantConversationsStore.getState()
-    const existing = store.conversations.find((meta) => meta.id === threadId)
+    const existing = store.conversations.find(
+      (meta) => meta.id === conversationId,
+    )
     if (existing?.title) return
-    store.rename(threadId, titleFromText(seed))
+    store.rename(conversationId, titleFromText(seed))
 
     let cancelled = false
     void generateConversationTitle(depsRef.current.pluginManager, seed).then(
       (title) => {
         if (cancelled || !title) return
-        useAssistantConversationsStore.getState().rename(threadId, title)
+        useAssistantConversationsStore.getState().rename(conversationId, title)
       },
     )
     return () => {
       cancelled = true
     }
-  }, [messages, threadId])
+  }, [messages, conversationId])
 
   // ── Sending ───────────────────────────────────────────────────────
   const pendingQuestion = findPendingQuestion(messages)
@@ -488,12 +474,14 @@ function AssistantConversationInner({
 
   const send = useCallback(
     (text: string) => {
-      runStartRef.current = Date.now()
-      runToolCallsRef.current = 0
+      runStatsRef.current.set(conversationId, {
+        start: Date.now(),
+        tools: 0,
+      })
       jumpToLatest()
       sendMessage({ text })
     },
-    [sendMessage, jumpToLatest],
+    [sendMessage, jumpToLatest, conversationId],
   )
 
   // One message may wait for the run in flight. A turn can span 28 steps
@@ -501,8 +489,19 @@ function AssistantConversationInner({
   // it, so a correction that occurred to the user halfway through was
   // simply lost. A backlog is deliberately not supported: the second
   // queued message would be answered with context from before an answer
-  // the user has not read yet.
-  const [queued, setQueued] = useState<string | null>(null)
+  // the user has not read yet. Keyed per thread so a follow-up typed
+  // here is not flushed into the conversation they switched to.
+  const queued =
+    queuedEpoch < 0 ? null : (queuedByIdRef.current.get(conversationId) ?? null)
+
+  const setQueued = useCallback(
+    (text: string | null) => {
+      if (text === null) queuedByIdRef.current.delete(conversationId)
+      else queuedByIdRef.current.set(conversationId, text)
+      setQueuedEpoch((n) => n + 1)
+    },
+    [conversationId],
+  )
 
   const handleSend = useCallback(
     (text: string) => {
@@ -525,7 +524,7 @@ function AssistantConversationInner({
       }
       send(text)
     },
-    [send, status, pendingQuestion, answerQuestion, jumpToLatest],
+    [send, status, pendingQuestion, answerQuestion, jumpToLatest, setQueued],
   )
   handleSendRef.current = handleSend
 
@@ -564,10 +563,9 @@ function AssistantConversationInner({
 
   const handleRegenerate = useCallback(() => {
     track('assistant_regenerated', { after_error: Boolean(error) })
-    runStartRef.current = Date.now()
-    runToolCallsRef.current = 0
+    runStatsRef.current.set(conversationId, { start: Date.now(), tools: 0 })
     regenerate()
-  }, [regenerate, error])
+  }, [regenerate, error, conversationId])
 
   // ── Order execution for the confirm cards ─────────────────────────
   const orderActions = useMemo<CopilotOrderActions>(
@@ -771,12 +769,13 @@ function AssistantConversationInner({
   useEffect(() => {
     if (!error || trackedErrorRef.current === error) return
     trackedErrorRef.current = error
+    const stats = runStatsRef.current.get(conversationId)
     track('assistant_run_completed', {
       outcome: 'error',
-      tool_calls: runToolCallsRef.current,
-      duration_ms: runStartRef.current ? Date.now() - runStartRef.current : 0,
+      tool_calls: stats?.tools ?? 0,
+      duration_ms: stats?.start ? Date.now() - stats.start : 0,
     })
-  }, [error])
+  }, [error, conversationId])
 
   return (
     <CopilotOrderActionsProvider value={orderActions}>

--- a/apps/terminal/src/lib/assistant-core/__tests__/chat-sessions.test.ts
+++ b/apps/terminal/src/lib/assistant-core/__tests__/chat-sessions.test.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Juan Ignacio Molina Estrada
+// SPDX-License-Identifier: FSL-1.1-Apache-2.0
+/**
+ * Switching History used to abort the run: the chat was one Chat keyed
+ * on the visible thread, and the switch effect called stop() before
+ * swapping the id. These pin a map that keeps each thread's Chat alive
+ * so a click on another row is the same as minimizing.
+ */
+import { describe, expect, test } from 'bun:test'
+
+import { AssistantChatSessions } from '../chat-sessions'
+import type { ChatSession } from '../chat-sessions'
+
+type Fake = ChatSession & {
+  stopped: boolean
+  setStatus: (status: string) => void
+  pushMessage: () => void
+}
+
+const fake = (id: string, messages: Array<unknown> = [{}]): Fake => {
+  let status = 'ready'
+  const messageCbs = new Set<() => void>()
+  const statusCbs = new Set<() => void>()
+  const chat: Fake = {
+    id,
+    messages,
+    get status() {
+      return status
+    },
+    stopped: false,
+    stop() {
+      this.stopped = true
+    },
+    sendMessage() {},
+    setStatus(next) {
+      status = next
+      for (const cb of statusCbs) cb()
+    },
+    pushMessage() {
+      for (const cb of messageCbs) cb()
+    },
+    '~registerMessagesCallback'(onChange) {
+      messageCbs.add(onChange)
+      return () => {
+        messageCbs.delete(onChange)
+      }
+    },
+    '~registerStatusCallback'(onChange) {
+      statusCbs.add(onChange)
+      return () => {
+        statusCbs.delete(onChange)
+      }
+    },
+  }
+  return chat
+}
+
+describe('AssistantChatSessions', () => {
+  test('get returns the same Chat for a thread after another is opened', () => {
+    const created: Array<string> = []
+    const sessions = new AssistantChatSessions({
+      create: (id) => {
+        created.push(id)
+        return fake(id)
+      },
+      persist: () => {},
+    })
+    const a = sessions.get('a')
+    const b = sessions.get('b')
+    expect(b).not.toBe(a)
+    expect(sessions.get('a')).toBe(a)
+    expect(created).toEqual(['a', 'b'])
+  })
+
+  test('prune stops and drops threads that were deleted, and leaves the rest', () => {
+    const sessions = new AssistantChatSessions({
+      create: (id) => fake(id),
+      persist: () => {},
+    })
+    const a = sessions.get('a')
+    const gone = sessions.get('gone')
+    sessions.prune(['a'])
+    expect(gone.stopped).toBe(true)
+    expect(a.stopped).toBe(false)
+    expect(sessions.get('a')).toBe(a)
+    expect(sessions.get('gone')).not.toBe(gone)
+  })
+
+  test('a streaming thread is persisted even when it is not the one on screen', () => {
+    const writes: Array<{ id: string; n: number }> = []
+    const sessions = new AssistantChatSessions({
+      create: (id) => fake(id, [{ n: 1 }]),
+      persist: (id, messages) => {
+        writes.push({ id, n: messages.length })
+      },
+      debounceMs: 0,
+    })
+    const a = sessions.get('a')
+    sessions.get('b')
+    a.setStatus('streaming')
+    a.pushMessage()
+    expect(writes.some((w) => w.id === 'a')).toBe(true)
+  })
+
+  test('dispose stops every live Chat', () => {
+    const sessions = new AssistantChatSessions({
+      create: (id) => fake(id),
+      persist: () => {},
+    })
+    const a = sessions.get('a')
+    const b = sessions.get('b')
+    sessions.dispose()
+    expect(a.stopped).toBe(true)
+    expect(b.stopped).toBe(true)
+  })
+})

--- a/apps/terminal/src/lib/assistant-core/chat-sessions.ts
+++ b/apps/terminal/src/lib/assistant-core/chat-sessions.ts
@@ -1,0 +1,184 @@
+// Copyright (c) 2026 Juan Ignacio Molina Estrada
+// SPDX-License-Identifier: FSL-1.1-Apache-2.0
+// ── One Chat per conversation ────────────────────────────────────────
+//
+// `useChat({ id })` rebuilds its Chat whenever the id moves. Switching
+// History used to stop the outgoing run first so that rebuild would not
+// orphan a stream. The cost was that a click on another row aborted the
+// answer, which minimizing the dock does not.
+//
+// This map keeps each thread's Chat alive. The hook is handed the
+// instance (`useChat({ chat })`), so a switch only changes which Chat
+// is on screen. The previous one keeps streaming, and coming back is
+// the same as un-minimizing.
+
+import { deriveRunStatus } from './run-status'
+import type { AssistantRunStatus } from './run-status'
+import type { UIMessage } from 'ai'
+
+export type ChatSession = {
+  id: string
+  status: string
+  messages: ReadonlyArray<unknown>
+  stop: () => unknown
+  sendMessage: (message: { text: string }) => unknown
+  '~registerMessagesCallback': (onChange: () => void) => () => void
+  '~registerStatusCallback': (onChange: () => void) => () => void
+}
+
+export type AssistantChatSessionsOptions<T extends ChatSession> = {
+  create: (id: string) => T
+  persist: (id: string, messages: T['messages']) => void
+  debounceMs?: number
+  /** Fired when a run reaches ready/error from a non-idle status. */
+  onReady?: (id: string, chat: T) => void
+}
+
+const DEFAULT_DEBOUNCE_MS = 700
+
+const IDLE: AssistantRunStatus = { phase: 'idle', toolName: null }
+
+export class AssistantChatSessions<T extends ChatSession> {
+  private readonly chats = new Map<string, T>()
+  private readonly unsubs = new Map<string, () => void>()
+  private readonly timers = new Map<string, ReturnType<typeof setTimeout>>()
+  private readonly lastStatus = new Map<string, string>()
+  private readonly orbKey = new Map<string, string>()
+  private revision = 0
+  private readonly listeners = new Set<() => void>()
+
+  constructor(private readonly options: AssistantChatSessionsOptions<T>) {}
+
+  get(id: string): T {
+    const existing = this.chats.get(id)
+    if (existing) return existing
+    const chat = this.options.create(id)
+    this.chats.set(id, chat)
+    this.lastStatus.set(id, chat.status)
+    this.unsubs.set(id, this.watch(id, chat))
+    return chat
+  }
+
+  /**
+   * Drop Chats whose threads no longer exist. Stops a run that was still
+   * in flight: deleting the conversation is the one way to abort it.
+   * An empty live set is ignored so a first-load blank index cannot
+   * wipe sessions the host has not published yet.
+   */
+  prune(liveIds: Iterable<string>): void {
+    const live = new Set(liveIds)
+    if (live.size === 0) return
+    for (const [id, chat] of this.chats) {
+      if (live.has(id)) continue
+      this.drop(id, chat)
+    }
+  }
+
+  dispose(): void {
+    for (const [id, chat] of [...this.chats]) {
+      this.drop(id, chat)
+    }
+  }
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  getSnapshot = (): number => this.revision
+
+  busiestStatus(): AssistantRunStatus {
+    for (const chat of this.chats.values()) {
+      const status = deriveRunStatus(
+        chat.messages as Array<UIMessage>,
+        chat.status,
+      )
+      if (status.phase !== 'idle') return status
+    }
+    return IDLE
+  }
+
+  private watch(id: string, chat: T): () => void {
+    const onChange = () => {
+      this.schedule(id, chat)
+      this.considerOrb(id, chat)
+      const prev = this.lastStatus.get(id)
+      this.lastStatus.set(id, chat.status)
+      if (
+        prev &&
+        prev !== 'ready' &&
+        prev !== 'error' &&
+        (chat.status === 'ready' || chat.status === 'error')
+      ) {
+        this.options.onReady?.(id, chat)
+      }
+    }
+    const unsubM = chat['~registerMessagesCallback'](onChange)
+    const unsubS = chat['~registerStatusCallback'](onChange)
+    return () => {
+      unsubM()
+      unsubS()
+    }
+  }
+
+  private considerOrb(id: string, chat: T): void {
+    const status = deriveRunStatus(
+      chat.messages as Array<UIMessage>,
+      chat.status,
+    )
+    const key = `${status.phase}:${status.toolName ?? ''}`
+    if (this.orbKey.get(id) === key) return
+    this.orbKey.set(id, key)
+    this.bump()
+  }
+
+  private schedule(id: string, chat: T): void {
+    if (chat.messages.length === 0) return
+    if (chat.status === 'ready' || chat.status === 'error') {
+      this.flush(id, chat)
+      return
+    }
+    const wait = this.options.debounceMs ?? DEFAULT_DEBOUNCE_MS
+    if (wait <= 0) {
+      this.persistNow(id, chat)
+      return
+    }
+    if (this.timers.has(id)) return
+    const timer = setTimeout(() => {
+      this.timers.delete(id)
+      this.persistNow(id, chat)
+    }, wait)
+    this.timers.set(id, timer)
+  }
+
+  private flush(id: string, chat: T): void {
+    const timer = this.timers.get(id)
+    if (timer) {
+      clearTimeout(timer)
+      this.timers.delete(id)
+    }
+    this.persistNow(id, chat)
+  }
+
+  private persistNow(id: string, chat: T): void {
+    if (chat.messages.length === 0) return
+    this.options.persist(id, chat.messages)
+  }
+
+  private drop(id: string, chat: T): void {
+    this.flush(id, chat)
+    this.unsubs.get(id)?.()
+    this.unsubs.delete(id)
+    this.lastStatus.delete(id)
+    this.orbKey.delete(id)
+    void chat.stop()
+    this.chats.delete(id)
+  }
+
+  private bump(): void {
+    this.revision += 1
+    for (const listener of this.listeners) listener()
+  }
+}


### PR DESCRIPTION
## What and why

Clicking another conversation in History used to kill the answer that was still writing. The dock keyed `useChat` on the visible thread id, so a switch had to `stop()` the outgoing run first. Otherwise the SDK rebuilt `Chat` around the new thread and orphaned the stream: tokens kept arriving into an object nothing rendered, and the half-answer never got written. Minimizing already kept the run alive. Switching rows did not, which made History feel like a stop button.

Each thread now keeps its own `Chat` in `AssistantChatSessions`. The hook is handed the instance (`useChat({ chat })`), so a History click only changes which Chat is on screen. The previous one keeps streaming, persists in the background, and is there when you come back, the same way un-minimizing works. Deleting a conversation is the one way a live run on that thread is aborted (`prune` stops and drops Chats whose threads no longer exist).

The orb reports the busiest non-idle run across every live Chat, so a background answer still shows **Thinking...** / **Using tools...** while you read another thread. Per-thread run stats replace the old shared refs, so a background finish is not credited to whichever thread sent last.

Docs (`ai-copilot.md`) match the new behaviour. Tests pin the session map (same Chat after another is opened, prune vs leave-the-rest, background persist, dispose) and the dock wiring (`useChat({ chat })`, no `stop()` / `clearScreenshots()` on a History click).

No connector or exchange-trading changes. No secrets in the diff.

## Checklist

- [ ] `bun run typecheck`, `bun run lint`, `bun run format`, `bun run test` all pass
- [x] Tests added or updated for behavior changes
- [ ] Connector changes pass `bun run test:conformance`
- [x] No real exchange API keys, wallet secrets, or seed phrases anywhere in the diff

## Contributor License Agreement

First PR here? The CLA bot will comment with a one-line signing instruction and
the `cla` check stays red until you post it. Signing takes one comment, once per
contributor, and it is what lets us ship your work under the FSL and its
two-year Apache 2.0 conversion. Details in
[CONTRIBUTING.md](https://github.com/Pairlens/trading-terminal/blob/main/CONTRIBUTING.md#contributor-license-agreement).

If your employer owns your work, they execute the
[Corporate CLA](https://github.com/Pairlens/trading-terminal/blob/main/CLA/corporate-cla.md)
instead and list you as a designated contributor.