### PR TITLE
fix(assistant): get_chart_indicators returns computed values, not just settings

### DIFF
--- a/apps/marketing/src/content/docs/copilot-tools.md
+++ b/apps/marketing/src/content/docs/copilot-tools.md
@@ -5,7 +5,7 @@ group: builders
 parent: agent-interfaces
 order: 1
 eyebrow: For builders
-updated: 22 AUG 2026
+updated: 4 SEP 2026
 readTime: 13 min read
 ---
 
@@ -216,6 +216,9 @@ and show me" ends with a picture rather than a sentence.
 **Read-back (3).** `get_chart_state`, `get_chart_indicators`,
 `get_chart_drawings`. These are what let it answer questions about what is
 already on your chart, including levels you drew yourself.
+`get_chart_indicators` returns each indicator's latest computed point plus
+the last 30 bars of values, so a question about RSI, StochRSI or an EMA
+cross is answered from the numbers on the chart, not just the settings.
 
 The first 27 are the gated ones. On the bots page there is no chart, so they are
 not offered; ask for a drawing there and the assistant navigates to a chart

--- a/apps/terminal/src/lib/assistant-core/__tests__/client-tools-snapshot.test.ts
+++ b/apps/terminal/src/lib/assistant-core/__tests__/client-tools-snapshot.test.ts
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 Juan Ignacio Molina Estrada
+// SPDX-License-Identifier: FSL-1.1-Apache-2.0
+// get_chart_indicators must hand the model computed values, not just the
+// indicator's type and params. The engine already holds those values; the
+// snapshot used to drop them by asking for the lite payload and mapping
+// only id/type/params.
+import { describe, expect, it } from 'bun:test'
+
+import type { FastFinancialChartRef } from '@pairlens/fast-financial-charts/types'
+import { buildChartSnapshot } from '@/lib/assistant-core/client-tools'
+
+const HOUR = 3_600_000
+const T0 = Date.UTC(2026, 8, 4, 0, 0, 0)
+
+type EngineSnapshotOptions = {
+  includeSeries?: boolean
+  includeIndicatorValues?: boolean
+}
+
+type IndicatorRow = {
+  id: string
+  type: string
+  params?: Record<string, unknown>
+}
+
+type ValuePoint = {
+  ts: number
+  value?: number
+  [key: string]: boolean | number | string | undefined
+}
+
+function fakeChart(opts: {
+  indicators: Array<IndicatorRow>
+  results: Array<{ id: string; values: Array<ValuePoint> }>
+  timeframe?: string
+}): FastFinancialChartRef {
+  const lite = {
+    timeframe: opts.timeframe ?? '1h',
+    indicators: opts.indicators,
+    drawings: [],
+    viewport: { startIndex: 0, endIndex: 10 },
+  }
+  return {
+    getSnapshot: (options?: EngineSnapshotOptions) => {
+      if (!options?.includeIndicatorValues) return lite
+      return {
+        ...lite,
+        series: [],
+        indicatorResults: opts.results.map((result) => ({
+          indicator: opts.indicators.find((row) => row.id === result.id) ?? {
+            id: result.id,
+            type: 'EMA',
+          },
+          values: result.values,
+          computedAt: T0,
+        })),
+      }
+    },
+    data: () => Array.from({ length: 80 }, (_, i) => ({ ts: T0 + i * HOUR })),
+    seriesOrder: () => ['BTC-USDT'],
+  } as unknown as FastFinancialChartRef
+}
+
+describe('buildChartSnapshot indicators', () => {
+  it('includes the last computed point and a recent window of values', () => {
+    const values = [
+      { ts: T0, value: 40 },
+      { ts: T0 + HOUR, value: 55.2 },
+    ]
+    const snap = buildChartSnapshot(
+      fakeChart({
+        indicators: [{ id: 'rsi-1', type: 'RSI', params: { period: 14 } }],
+        results: [{ id: 'rsi-1', values }],
+      }),
+    )
+
+    expect(snap?.indicators).toEqual([
+      {
+        id: 'rsi-1',
+        type: 'RSI',
+        params: { period: 14 },
+        latest: { ts: T0 + HOUR, value: 55.2 },
+        values,
+      },
+    ])
+  })
+
+  it('keeps multi-plot keys so StochRSI and EMACross are readable', () => {
+    const snap = buildChartSnapshot(
+      fakeChart({
+        indicators: [
+          {
+            id: 'stoch-1',
+            type: 'StochRSI',
+            params: { rsiPeriod: 14, stochPeriod: 14, kSmooth: 3, dSmooth: 3 },
+          },
+          {
+            id: 'cross-1',
+            type: 'EMACross',
+            params: { fastPeriod: 12, slowPeriod: 26 },
+          },
+        ],
+        results: [
+          {
+            id: 'stoch-1',
+            values: [
+              { ts: T0, k: 22, d: 18 },
+              { ts: T0 + HOUR, k: 81.4, d: 74.1 },
+            ],
+          },
+          {
+            id: 'cross-1',
+            values: [
+              { ts: T0, fast: 100, slow: 101 },
+              { ts: T0 + HOUR, fast: 102.5, slow: 101.2 },
+            ],
+          },
+        ],
+      }),
+    )
+
+    expect(snap?.indicators?.[0]?.latest).toEqual({
+      ts: T0 + HOUR,
+      k: 81.4,
+      d: 74.1,
+    })
+    expect(snap?.indicators?.[1]?.latest).toEqual({
+      ts: T0 + HOUR,
+      fast: 102.5,
+      slow: 101.2,
+    })
+    expect(snap?.indicators?.[0]?.values).toHaveLength(2)
+    expect(snap?.indicators?.[1]?.values).toHaveLength(2)
+  })
+
+  it('caps the value window so a long series does not flood the model', () => {
+    const values = Array.from({ length: 80 }, (_, i) => ({
+      ts: T0 + i * HOUR,
+      value: i,
+    }))
+    const snap = buildChartSnapshot(
+      fakeChart({
+        indicators: [{ id: 'ema-1', type: 'EMA', params: { period: 21 } }],
+        results: [{ id: 'ema-1', values }],
+      }),
+    )
+
+    expect(snap?.indicators?.[0]?.values).toEqual(values.slice(-30))
+    expect(snap?.indicators?.[0]?.latest).toEqual({
+      ts: T0 + 79 * HOUR,
+      value: 79,
+    })
+  })
+
+  it('still returns config when the engine has not computed yet', () => {
+    const snap = buildChartSnapshot(
+      fakeChart({
+        indicators: [
+          {
+            id: 'macd-1',
+            type: 'MACD',
+            params: { fast: 12, slow: 26, signal: 9 },
+          },
+        ],
+        results: [],
+      }),
+    )
+
+    expect(snap?.indicators).toEqual([
+      {
+        id: 'macd-1',
+        type: 'MACD',
+        params: { fast: 12, slow: 26, signal: 9 },
+        latest: null,
+        values: [],
+      },
+    ])
+  })
+})

--- a/apps/terminal/src/lib/assistant-core/client-tools.ts
+++ b/apps/terminal/src/lib/assistant-core/client-tools.ts
@@ -13,12 +13,15 @@
 import { putScreenshot } from './screenshot-store'
 import type { useNavigate } from '@tanstack/react-router'
 import type {
+  ChartSnapshot,
   FastFinancialChartRef,
   IndicatorInstanceInput,
+  IndicatorValuePoint,
 } from '@pairlens/fast-financial-charts/types'
 import type { InstrumentRef, MarketRef } from '@pairlens/shared/market-ref'
 import type {
   CopilotChartSnapshot,
+  CopilotIndicatorPoint,
   CopilotMarketDataHandle,
 } from '@/lib/copilot/tool-deps'
 import type { useMarketData } from '@/lib/market-data-provider'
@@ -343,48 +346,62 @@ export function executeClientTool(
   }
 }
 
+/** Matches `get_candles`' recent window: enough to see a cross, not a 500-bar dump. */
+const INDICATOR_VALUE_BARS = 30
+
+function isValueSnapshot(
+  snapshot: ReturnType<FastFinancialChartRef['getSnapshot']>,
+): snapshot is ChartSnapshot {
+  return 'indicatorResults' in snapshot
+}
+
+function toIndicatorPoint(point: IndicatorValuePoint): CopilotIndicatorPoint {
+  return point as CopilotIndicatorPoint
+}
+
 /** Extract a compact chart snapshot for the copilot's chart-query tools. */
 export function buildChartSnapshot(
   chart: FastFinancialChartRef | null,
 ): CopilotChartSnapshot | null {
   if (!chart) return null
-  const ref = chart as unknown as {
-    getSnapshot?: (o?: unknown) => Record<string, unknown>
-    data?: () => Array<unknown>
-    seriesOrder?: () => Array<string>
-  }
-  if (!ref.getSnapshot) return null
   try {
-    const s = ref.getSnapshot() ?? {}
-    const indicators = Array.isArray(s.indicators)
-      ? (s.indicators as Array<Record<string, unknown>>).map((ind) => ({
-          id: String(ind.id ?? ''),
-          type: String(ind.type ?? ''),
-          params: ind.params as Record<string, unknown> | undefined,
-        }))
-      : []
-    const drawings = Array.isArray(s.drawings)
-      ? (s.drawings as Array<Record<string, unknown>>).map((d) => ({
-          id: String(d.id ?? ''),
-          type: String(d.type ?? ''),
-        }))
-      : []
-    const viewport = s.viewport as
-      | { startIndex?: number; endIndex?: number }
-      | undefined
-    const seriesOrder = ref.seriesOrder?.() ?? []
+    const s = chart.getSnapshot({ includeIndicatorValues: true })
+    const valuesById = new Map<string, Array<CopilotIndicatorPoint>>()
+    if (isValueSnapshot(s)) {
+      for (const result of s.indicatorResults) {
+        valuesById.set(
+          result.indicator.id,
+          result.values.slice(-INDICATOR_VALUE_BARS).map(toIndicatorPoint),
+        )
+      }
+    }
+    const indicators = s.indicators.map((ind) => {
+      const values = valuesById.get(ind.id) ?? []
+      return {
+        id: ind.id,
+        type: String(ind.type),
+        params: ind.params as Record<string, unknown> | undefined,
+        latest: values[values.length - 1] ?? null,
+        values,
+      }
+    })
+    const drawings = s.drawings.map((d) => ({
+      id: d.id,
+      type: String(d.type),
+    }))
+    const viewport = s.viewport
     return {
-      timeframe: s.timeframe as string | undefined,
-      chartType: s.chartType as string | undefined,
-      priceScaleMode: s.priceScaleMode as string | undefined,
+      timeframe: s.timeframe,
+      chartType: s.chartType,
+      priceScaleMode: 'priceScaleMode' in s ? s.priceScaleMode : undefined,
       indicators,
       drawings,
       visibleRange:
         viewport?.startIndex != null && viewport?.endIndex != null
           ? { startIndex: viewport.startIndex, endIndex: viewport.endIndex }
           : undefined,
-      barCount: ref.data?.().length,
-      compareSymbols: seriesOrder.slice(1),
+      barCount: chart.data?.().length,
+      compareSymbols: chart.seriesOrder?.().slice(1),
     }
   } catch {
     return null

--- a/apps/terminal/src/lib/copilot/chart-tools.ts
+++ b/apps/terminal/src/lib/copilot/chart-tools.ts
@@ -304,7 +304,7 @@ export function buildChartTools(deps: CopilotToolDeps) {
     }),
     get_chart_indicators: tool({
       description:
-        'Read the indicators currently applied to the chart, with their latest computed values where available (e.g. current RSI).',
+        'Read the indicators currently applied to the chart, with their latest computed point and the last 30 bars of values (RSI `value`, StochRSI `k`/`d`, EMACross `fast`/`slow`, MACD `macd`/`signal`/`histogram`).',
       inputSchema: z.object({}),
       execute: async () => {
         const snap = deps.getChartSnapshot()

--- a/apps/terminal/src/lib/copilot/tool-deps.ts
+++ b/apps/terminal/src/lib/copilot/tool-deps.ts
@@ -248,6 +248,12 @@ export type CopilotMarketDataHandle = {
   ) => () => void
 }
 
+/** One computed indicator sample. RSI uses `value`; StochRSI uses `k`/`d`; EMACross uses `fast`/`slow`. */
+export type CopilotIndicatorPoint = {
+  ts: number
+  [key: string]: boolean | number | string | undefined
+}
+
 export type CopilotChartSnapshot = {
   timeframe?: string
   chartType?: string
@@ -256,7 +262,10 @@ export type CopilotChartSnapshot = {
     id: string
     type: string
     params?: Record<string, unknown>
-    latest?: number | null
+    /** Last computed point, or null while the engine has not produced values yet. */
+    latest?: CopilotIndicatorPoint | null
+    /** Most recent computed points, newest last, capped so a long series stays compact. */
+    values?: Array<CopilotIndicatorPoint>
   }>
   drawings?: Array<{ id: string; type: string }>
   visibleRange?: { startIndex: number; endIndex: number }


### PR DESCRIPTION
## What and why

`get_chart_indicators` already claimed to return latest computed values (current RSI, and so on). It did not. The snapshot asked the chart engine for the lite payload and mapped only `id` / `type` / `params`, so the model could see that an RSI(14) was on the chart and nothing about whether it was 32 or 78. Questions about RSI, StochRSI, or an EMA cross were answered from settings, not from the numbers on the screen.

The snapshot now requests `includeIndicatorValues` and attaches each indicator's latest computed point plus the last 30 bars (same window as `get_candles`). Multi-plot keys stay intact: StochRSI `k`/`d`, EMACross `fast`/`slow`, MACD `macd`/`signal`/`histogram`. If the engine has not computed yet, the tool still returns the config with `latest: null` and an empty `values` array rather than omitting the indicator.

The tool description and `copilot-tools.md` match the payload. Tests pin the latest point, the 30-bar cap, multi-plot keys, and the not-yet-computed case.

No new product events: this is a bugfix of an existing tool payload. No connector or exchange-trading changes. No secrets in the diff.

## Checklist

- [ ] `bun run typecheck`, `bun run lint`, `bun run format`, `bun run test` all pass
- [x] Tests added or updated for behavior changes
- [ ] Connector changes pass `bun run test:conformance`
- [x] No real exchange API keys, wallet secrets, or seed phrases anywhere in the diff

## Contributor License Agreement

First PR here? The CLA bot will comment with a one-line signing instruction and
the `cla` check stays red until you post it. Signing takes one comment, once per
contributor, and it is what lets us ship your work under the FSL and its
two-year Apache 2.0 conversion. Details in
[CONTRIBUTING.md](https://github.com/Pairlens/trading-terminal/blob/main/CONTRIBUTING.md#contributor-license-agreement).

If your employer owns your work, they execute the
[Corporate CLA](https://github.com/Pairlens/trading-terminal/blob/main/CLA/corporate-cla.md)
instead and list you as a designated contributor.